### PR TITLE
Bug fix for FromStartAndEnd parameter set

### DIFF
--- a/Indented.Net.IP/public/Get-NetworkRange.ps1
+++ b/Indented.Net.IP/public/Get-NetworkRange.ps1
@@ -41,14 +41,14 @@ function Get-NetworkRange {
     )
 
     process {
-        try {
-            $null = $psboundparameters.Remove('IncludeNetworkAndBroadcast')
-            $network = ConvertToNetwork @psboundparameters
-        } catch {
-            $pscmdlet.ThrowTerminatingError($_)
-        }
-
         if ($pscmdlet.ParameterSetName -eq 'FromIPAndMask') {
+            try {
+                $null = $psboundparameters.Remove('IncludeNetworkAndBroadcast')
+                $network = ConvertToNetwork @psboundparameters
+            } catch {
+                $pscmdlet.ThrowTerminatingError($_)
+            }
+
             $decimalIP = ConvertTo-DecimalIP $network.IPAddress
             $decimalMask = ConvertTo-DecimalIP $network.SubnetMask
 

--- a/Indented.Net.IP/test/public/Get-NetworkRange.tests.ps1
+++ b/Indented.Net.IP/test/public/Get-NetworkRange.tests.ps1
@@ -32,5 +32,15 @@ InModuleScope Indented.Net.IP {
                 $ScriptBlock | Should Not Throw
             }
         }
+
+        It 'Returns correct values when used with Start and End parameters' {
+            $StartIP = [System.Net.IPAddress]'192.168.1.1'
+            $EndIP = [System.Net.IPAddress]'192.168.2.10'
+            $Assertion = Get-NetworkRange -Start $StartIP -End $EndIP
+
+            $Assertion.Count | Should BeExactly 266
+            $Assertion[0].IPAddressToString | Should BeExactly '192.168.1.1'
+            $Assertion[-1].IPAddressToString | Should BeExactly '192.168.2.10'
+        }
     }
 }


### PR DESCRIPTION
Resolves the ```Get-NetworkRange``` ```FromStartAndEnd``` parameter set issue raised in #4.